### PR TITLE
Prevent restarting completed session workers

### DIFF
--- a/app/api/routes/uploads.py
+++ b/app/api/routes/uploads.py
@@ -299,6 +299,17 @@ def _start_single_session_worker(session_id: int) -> None:
                     if session_obj is None:
                         return
 
+                    if session_obj.status == "completed" or session_obj.progress >= 100:
+                        session_obj.status = "completed"
+                        session_obj.progress = 100
+                        session_obj.current_step = session_obj.current_step or "completed"
+                        if session_obj.started_at is None:
+                            session_obj.started_at = datetime.now(tz=timezone.utc)
+                        if session_obj.finished_at is None:
+                            session_obj.finished_at = datetime.now(tz=timezone.utc)
+                        await session.commit()
+                        return
+
                     if not SIMULATED_PIPELINE_STEPS:
                         session_obj.status = "completed"
                         session_obj.progress = 100


### PR DESCRIPTION
## Summary
- add a guard in the background worker to skip processing sessions that are already completed
- ensure completed sessions retain their finished metadata instead of being reset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22f1e0948832e9f6edbcb51dbe809