### PR TITLE
Improve SQLite concurrency handling

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,12 +1,22 @@
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import event
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from .config import get_settings
 
 settings = get_settings()
-engine = create_async_engine(settings.database_url, future=True)
+database_url = settings.database_url
+engine_kwargs: dict[str, object] = {"future": True}
+
+database_backend = make_url(database_url).get_backend_name()
+
+if database_backend == "sqlite":
+    engine_kwargs["connect_args"] = {"timeout": 30}
+
+engine = create_async_engine(database_url, **engine_kwargs)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 
@@ -21,3 +31,14 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 
     async with SessionLocal() as session:
         yield session
+
+
+if database_backend == "sqlite":
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, _: object) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL;")
+        cursor.execute("PRAGMA synchronous=NORMAL;")
+        cursor.execute("PRAGMA busy_timeout=30000;")
+        cursor.close()


### PR DESCRIPTION
## Summary
- configure the async engine to apply SQLite-specific timeouts
- enable WAL journal mode, relaxed synchronous writes, and a busy timeout for SQLite connections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e231be611c832e839b867c544cb822