### PR TITLE
feat: persist dataset preprocessing associations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -349,6 +349,11 @@ class Dataset(Base):
         secondary=dataset_data_association,
         back_populates="datasets",
     )
+    preprocess_items: Mapped[list["DatasetPreprocessData"]] = relationship(
+        "DatasetPreprocessData",
+        back_populates="dataset",
+        cascade="all, delete-orphan",
+    )
     sessions: Mapped[list["Session"]] = relationship(back_populates="dataset")
 
 
@@ -377,7 +382,34 @@ class Data(Base):
         secondary=dataset_data_association,
         back_populates="data_items",
     )
+    preprocess_links: Mapped[list["DatasetPreprocessData"]] = relationship(
+        "DatasetPreprocessData",
+        back_populates="data",
+        cascade="all, delete-orphan",
+    )
     sessions: Mapped[list["Session"]] = relationship(back_populates="data")
+
+
+class DatasetPreprocessData(Base):
+    """Association between datasets and preprocessing data grouped by category."""
+
+    __tablename__ = "dataset_preprocess_data"
+
+    id: Mapped[int] = mapped_column(
+        BIGINT_PK, primary_key=True, index=True, autoincrement=True
+    )
+    dataset_id: Mapped[int] = mapped_column(
+        ForeignKey("dataset.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    data_id: Mapped[int] = mapped_column(
+        ForeignKey("data.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    category: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    __table_args__ = (UniqueConstraint("dataset_id", "data_id"),)
+
+    dataset: Mapped[Dataset] = relationship(back_populates="preprocess_items")
+    data: Mapped[Data] = relationship(back_populates="preprocess_links")
 
 
 class Session(Base):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date as Date, datetime
-from typing import Literal
+from typing import Literal, get_args
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
@@ -478,6 +478,7 @@ class DataRead(BaseModel):
 from pydantic import BaseModel, Field, ConfigDict
 
 PreprocessCategory = Literal["dark", "bias", "flat"]
+PREPROCESS_CATEGORY_VALUES: tuple[str, ...] = get_args(PreprocessCategory)
 
 
 class TempUploadItem(BaseModel):
@@ -599,6 +600,23 @@ class UploadCommitRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class DatasetPreprocessGroup(BaseModel):
+    dark: list[DataRead] = Field(
+        default_factory=list,
+        description="Dark frame preprocessing data items associated with the dataset.",
+    )
+    bias: list[DataRead] = Field(
+        default_factory=list,
+        description="Bias frame preprocessing data items associated with the dataset.",
+    )
+    flat: list[DataRead] = Field(
+        default_factory=list,
+        description="Flat field preprocessing data items associated with the dataset.",
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 # -----------------------
 # Session & pipeline schemas
 # -----------------------
@@ -681,6 +699,10 @@ class UploadCommitResponse(BaseModel):
         default_factory=list,
         description="Committed preprocessing files persisted to storage.",
     )
+    preprocess_grouped: DatasetPreprocessGroup = Field(
+        default_factory=DatasetPreprocessGroup,
+        description="Preprocessing files grouped by calibration category.",
+    )
     sessions: list[SessionRead] = Field(description="Sessions spawned for each committed data item.")
 
     model_config = ConfigDict(extra="forbid")
@@ -730,6 +752,7 @@ __all__ = [
     "DataRead",
     "DatasetCreate",
     "DatasetRead",
+    "DatasetPreprocessGroup",
     "FollowCreate",
     "FollowRead",
     "FollowerCreate",
@@ -753,6 +776,7 @@ __all__ = [
     "StageUploadsResponse",
     "TempUploadItem",
     "TempPreprocessItem",
+    "PREPROCESS_CATEGORY_VALUES",
     "UploadCommitItem",
     "UploadCommitRequest",
     "UploadCommitResponse",


### PR DESCRIPTION
## Summary
- add a dedicated dataset_preprocess_data association model for calibration files
- update upload commit flow and response schemas to group preprocessing files per category
- expose a datasets/preprocess endpoint to retrieve grouped preprocessing data for a dataset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e230caf12c832e9a6bb214e86e0fd0