### PR TITLE
Make processing sessions operate at dataset level

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -387,7 +387,6 @@ class Data(Base):
         back_populates="data",
         cascade="all, delete-orphan",
     )
-    sessions: Mapped[list["Session"]] = relationship(back_populates="data")
 
 
 class DatasetPreprocessData(Base):
@@ -413,7 +412,7 @@ class DatasetPreprocessData(Base):
 
 
 class Session(Base):
-    """Processing run for a given data version."""
+    """Processing run for a committed dataset version."""
 
     __tablename__ = "sessions"
 
@@ -430,9 +429,6 @@ class Session(Base):
     dataset_id: Mapped[int] = mapped_column(
         ForeignKey("dataset.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    data_id: Mapped[int] = mapped_column(
-        ForeignKey("data.id", ondelete="CASCADE"), nullable=False, index=True
-    )
     data_version: Mapped[int] = mapped_column(Integer, nullable=False)
     current_step: Mapped[str | None] = mapped_column(String(32))
     status: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -444,11 +440,8 @@ class Session(Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    __table_args__ = (UniqueConstraint("dataset_id", "data_id"),)
-
     repository: Mapped[Repository] = relationship(back_populates="sessions")
     dataset: Mapped[Dataset] = relationship(back_populates="sessions")
-    data: Mapped[Data] = relationship(back_populates="sessions")
     pipeline_steps: Mapped[list["PipelineStep"]] = relationship(
         back_populates="session",
         cascade="all, delete-orphan",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -631,13 +631,9 @@ class SessionRead(SessionSummary):
         default=None,
         description="Dataset associated with the session.",
     )
-    data_id: int | None = Field(
-        default=None,
-        description="Data item processed by the session.",
-    )
     data_version: int | None = Field(
         default=None,
-        description="Version value tracked for the data item when the session ran.",
+        description="Dataset version value tracked when the session ran.",
     )
 
     model_config = ConfigDict(from_attributes=True)
@@ -703,7 +699,10 @@ class UploadCommitResponse(BaseModel):
         default_factory=DatasetPreprocessGroup,
         description="Preprocessing files grouped by calibration category.",
     )
-    sessions: list[SessionRead] = Field(description="Sessions spawned for each committed data item.")
+    session: SessionRead | None = Field(
+        default=None,
+        description="Processing session spawned to analyze the committed dataset.",
+    )
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
## Summary
- remove the per-data relationship from processing sessions so runs are tracked per dataset version
- update the upload commit flow and response schema to launch a single dataset session and expose it via the API
- refresh dummy seed data to generate dataset-level sessions that match the new model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e233a361b4832eaa248499b510c32e