### PR TITLE
Expose pipeline definition API endpoint

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,10 +1,21 @@
 """Route packages available for import convenience."""
 
-from . import datasets, health, projects, repositories, sessions, stats, uploads, users
+from . import (
+    datasets,
+    health,
+    pipeline,
+    projects,
+    repositories,
+    sessions,
+    stats,
+    uploads,
+    users,
+)
 
 __all__ = [
     "datasets",
     "health",
+    "pipeline",
     "projects",
     "repositories",
     "sessions",

--- a/app/api/routes/pipeline.py
+++ b/app/api/routes/pipeline.py
@@ -1,0 +1,31 @@
+"""Read-only endpoints exposing the canonical analysis pipeline definition."""
+
+from fastapi import APIRouter
+
+from ... import schemas
+from ...core import get_default_pipeline
+
+router = APIRouter(tags=["pipeline"])
+
+
+@router.get(
+    "/pipeline",
+    response_model=schemas.PipelineDefinitionRead,
+    summary="Get canonical pipeline definition",
+)
+async def get_pipeline_definition() -> schemas.PipelineDefinitionRead:
+    """Return the shared pipeline metadata including ordered steps."""
+
+    steps = [
+        schemas.PipelineDefinitionStep(
+            order=index,
+            name=step.name,
+            title=step.title,
+            description=step.description,
+        )
+        for index, step in enumerate(get_default_pipeline(), start=1)
+    ]
+    return schemas.PipelineDefinitionRead(steps=steps, total_steps=len(steps))
+
+
+__all__ = ["router"]

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,17 @@
+"""Core analysis step definitions used to assemble processing pipelines."""
+
+from .pipeline import (
+    DEFAULT_PIPELINE,
+    PipelineStepDefinition,
+    get_default_pipeline,
+    get_step,
+    iter_step_names,
+)
+
+__all__ = [
+    "DEFAULT_PIPELINE",
+    "PipelineStepDefinition",
+    "get_default_pipeline",
+    "get_step",
+    "iter_step_names",
+]

--- a/app/core/calibration.py
+++ b/app/core/calibration.py
@@ -1,0 +1,11 @@
+"""Simulated calibration step applying dark/bias/flat corrections."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "calibration"
+STEP_TITLE = "Calibrate exposures"
+STEP_DESCRIPTION = "Apply dark, bias, and flat-field corrections to raw frames."
+
+run_step = bind_runtime(2.0)

--- a/app/core/classification.py
+++ b/app/core/classification.py
@@ -1,0 +1,11 @@
+"""Simulated classification step for candidate events."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "classification"
+STEP_TITLE = "Classify events"
+STEP_DESCRIPTION = "Score extracted signals to prioritise follow-up."
+
+run_step = bind_runtime(1.4)

--- a/app/core/denoise.py
+++ b/app/core/denoise.py
@@ -1,0 +1,11 @@
+"""Simulated denoising step for extracted lightcurves."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "denoise"
+STEP_TITLE = "Denoise lightcurve"
+STEP_DESCRIPTION = "Reduce noise using frequency-domain filtering techniques."
+
+run_step = bind_runtime(1.0)

--- a/app/core/ingest.py
+++ b/app/core/ingest.py
@@ -1,0 +1,11 @@
+"""Simulated ingest step for the analysis pipeline."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "ingest"
+STEP_TITLE = "Ingest raw exposures"
+STEP_DESCRIPTION = "Pull uploaded FITS files into the processing workspace."
+
+run_step = bind_runtime(1.5)

--- a/app/core/lightcurve.py
+++ b/app/core/lightcurve.py
@@ -1,0 +1,11 @@
+"""Simulated lightcurve extraction step."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "lightcurve"
+STEP_TITLE = "Extract lightcurve"
+STEP_DESCRIPTION = "Generate time-series photometry for the aligned exposures."
+
+run_step = bind_runtime(1.8)

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -1,0 +1,103 @@
+"""Declarative pipeline configuration backed by core analysis steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Iterable, Mapping
+
+from . import (
+    calibration,
+    classification,
+    denoise,
+    ingest,
+    lightcurve,
+    registration,
+    reporting,
+)
+
+
+@dataclass(frozen=True)
+class PipelineStepDefinition:
+    """Metadata describing a single pipeline step."""
+
+    name: str
+    title: str
+    description: str
+    runner: Callable[[], Awaitable[None]]
+
+
+DEFAULT_PIPELINE: tuple[PipelineStepDefinition, ...] = (
+    PipelineStepDefinition(
+        name=ingest.STEP_NAME,
+        title=ingest.STEP_TITLE,
+        description=ingest.STEP_DESCRIPTION,
+        runner=ingest.run_step,
+    ),
+    PipelineStepDefinition(
+        name=calibration.STEP_NAME,
+        title=calibration.STEP_TITLE,
+        description=calibration.STEP_DESCRIPTION,
+        runner=calibration.run_step,
+    ),
+    PipelineStepDefinition(
+        name=registration.STEP_NAME,
+        title=registration.STEP_TITLE,
+        description=registration.STEP_DESCRIPTION,
+        runner=registration.run_step,
+    ),
+    PipelineStepDefinition(
+        name=lightcurve.STEP_NAME,
+        title=lightcurve.STEP_TITLE,
+        description=lightcurve.STEP_DESCRIPTION,
+        runner=lightcurve.run_step,
+    ),
+    PipelineStepDefinition(
+        name=denoise.STEP_NAME,
+        title=denoise.STEP_TITLE,
+        description=denoise.STEP_DESCRIPTION,
+        runner=denoise.run_step,
+    ),
+    PipelineStepDefinition(
+        name=classification.STEP_NAME,
+        title=classification.STEP_TITLE,
+        description=classification.STEP_DESCRIPTION,
+        runner=classification.run_step,
+    ),
+    PipelineStepDefinition(
+        name=reporting.STEP_NAME,
+        title=reporting.STEP_TITLE,
+        description=reporting.STEP_DESCRIPTION,
+        runner=reporting.run_step,
+    ),
+)
+
+_STEP_LOOKUP: Mapping[str, PipelineStepDefinition] = {
+    step.name: step for step in DEFAULT_PIPELINE
+}
+
+
+def get_default_pipeline() -> tuple[PipelineStepDefinition, ...]:
+    """Return the immutable default pipeline definition."""
+
+    return DEFAULT_PIPELINE
+
+
+def get_step(name: str) -> PipelineStepDefinition | None:
+    """Return metadata for a named step if it exists."""
+
+    return _STEP_LOOKUP.get(name)
+
+
+def iter_step_names() -> Iterable[str]:
+    """Iterate over canonical step names in execution order."""
+
+    return (step.name for step in DEFAULT_PIPELINE)
+
+
+__all__ = [
+    "PipelineStepDefinition",
+    "DEFAULT_PIPELINE",
+    "get_default_pipeline",
+    "get_step",
+    "iter_step_names",
+]

--- a/app/core/registration.py
+++ b/app/core/registration.py
@@ -1,0 +1,11 @@
+"""Simulated registration step for aligning frames."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "registration"
+STEP_TITLE = "Register exposures"
+STEP_DESCRIPTION = "Align frames against reference stars to stabilise the stack."
+
+run_step = bind_runtime(1.2)

--- a/app/core/reporting.py
+++ b/app/core/reporting.py
@@ -1,0 +1,11 @@
+"""Simulated reporting step producing summary artefacts."""
+
+from __future__ import annotations
+
+from .runtime import bind_runtime
+
+STEP_NAME = "reporting"
+STEP_TITLE = "Compile report"
+STEP_DESCRIPTION = "Generate session-level reports and notify subscribers."
+
+run_step = bind_runtime(0.8)

--- a/app/core/runtime.py
+++ b/app/core/runtime.py
@@ -1,0 +1,27 @@
+"""Runtime helpers for simulated pipeline steps."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+
+async def simulate_runtime(seconds: float = 1.0) -> None:
+    """Sleep in small increments to emulate work without blocking tests."""
+
+    # Sleep using small intervals to keep control responsive while keeping
+    # the total runtime deterministic for tests.
+    remaining = float(seconds)
+    interval = 0.1
+    while remaining > 0:
+        await asyncio.sleep(min(interval, remaining))
+        remaining -= interval
+
+
+def bind_runtime(seconds: float) -> Callable[[], Awaitable[None]]:
+    """Return a coroutine factory that simulates work for ``seconds`` seconds."""
+
+    async def _runner() -> None:
+        await simulate_runtime(seconds)
+
+    return _runner

--- a/app/docs.py
+++ b/app/docs.py
@@ -63,6 +63,10 @@ TAGS_METADATA = [
         "description": "Stage FITS files, commit uploads, and trigger processing sessions.",
     },
     {
+        "name": "pipeline",
+        "description": "Inspect the canonical analysis pipeline and step metadata.",
+    },
+    {
         "name": "sessions",
         "description": "Processing session history and pipeline step inspection.",
     },

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,17 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from .api.routes import datasets, health, projects, repositories, sessions, stats, uploads, users
+from .api.routes import (
+    datasets,
+    health,
+    pipeline,
+    projects,
+    repositories,
+    sessions,
+    stats,
+    uploads,
+    users,
+)
 from .config import get_settings
 from .database import Base, engine
 from .docs import (
@@ -46,6 +56,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router, prefix="/api")
     app.include_router(users.router, prefix="/api")
     app.include_router(repositories.router, prefix="/api")
+    app.include_router(pipeline.router, prefix="/api")
     app.include_router(projects.router, prefix="/api")
     app.include_router(datasets.router, prefix="/api")
     app.include_router(sessions.router, prefix="/api")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -639,6 +639,36 @@ class SessionRead(SessionSummary):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PipelineDefinitionStep(BaseModel):
+    order: int = Field(
+        description="1-based execution order for the pipeline step.",
+        examples=[1],
+    )
+    name: str = Field(
+        description="Canonical machine-readable identifier for the step.",
+        examples=["ingest"],
+    )
+    title: str = Field(
+        description="Human-friendly title describing the step.",
+        examples=["Raw ingestion"],
+    )
+    description: str = Field(
+        description="Detailed explanation of what the step performs.",
+        examples=["Load staged FITS data and validate headers."],
+    )
+
+
+class PipelineDefinitionRead(BaseModel):
+    steps: list[PipelineDefinitionStep] = Field(
+        default_factory=list,
+        description="Ordered list of pipeline steps executed by the service.",
+    )
+    total_steps: int = Field(
+        description="Total number of steps defined in the pipeline.",
+        examples=[7],
+    )
+
+
 class PipelineStepRead(BaseModel):
     step_id: int = Field(description="Unique step identifier within the run.")
     run_id: UUID = Field(description="Run identifier that owns the pipeline step.")
@@ -769,6 +799,8 @@ __all__ = [
     "PinRead",
     "PinReorder",
     "PipelineStepRead",
+    "PipelineDefinitionRead",
+    "PipelineDefinitionStep",
     "RepositoryLatestSessionRead",
     "ProjectCreate",
     "ProjectMemberCreate",

--- a/scripts/seed_dummy_data.py
+++ b/scripts/seed_dummy_data.py
@@ -14,6 +14,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.append(str(PROJECT_ROOT))
 
+from app.core import get_default_pipeline
 from app.database import Base, SessionLocal, engine
 from sqlalchemy import insert
 
@@ -212,21 +213,24 @@ async def seed_dummy_data() -> None:
 
         # --- Datasets, data files, sessions, and pipeline steps ---
         statuses = ["completed", "running", "failed", "queued"]
+        pipeline_steps = list(get_default_pipeline())
+        pipeline_names = [step.name for step in pipeline_steps]
         pipeline_templates = [
             [
-                {"name": "ingest", "status": "completed"},
-                {"name": "calibration", "status": "completed"},
-                {"name": "lightcurve", "status": "completed"},
+                {"name": pipeline_names[0], "status": "completed"},
+                {"name": pipeline_names[1], "status": "completed"},
+                {"name": pipeline_names[3], "status": "completed"},
+                {"name": pipeline_names[5], "status": "completed"},
             ],
             [
-                {"name": "ingest", "status": "completed"},
-                {"name": "registration", "status": "running"},
-                {"name": "classification", "status": "pending"},
+                {"name": pipeline_names[0], "status": "completed"},
+                {"name": pipeline_names[2], "status": "running"},
+                {"name": pipeline_names[5], "status": "pending"},
             ],
             [
-                {"name": "ingest", "status": "completed"},
-                {"name": "denoise", "status": "failed"},
-                {"name": "fallback", "status": "queued"},
+                {"name": pipeline_names[0], "status": "completed"},
+                {"name": pipeline_names[4], "status": "failed"},
+                {"name": pipeline_names[-1], "status": "queued"},
             ],
         ]
 


### PR DESCRIPTION
## Summary
- add a read-only pipeline endpoint that serves the canonical step metadata
- register the pipeline router and tag so the endpoint appears in the FastAPI docs
- extend the shared schemas with pipeline definition payloads for OpenAPI clients

## Testing
- python -m compileall app scripts

------
https://chatgpt.com/codex/tasks/task_e_68e2470c8340832e86fc6c459b2a7af8