### PR TITLE
Allow demo master login and relax credential validation

### DIFF
--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -90,13 +90,38 @@ async def create_user(payload: schemas.UserCreate, db: DBSession) -> schemas.Use
 async def login(payload: schemas.UserLogin, db: DBSession) -> schemas.AuthLoginResponse:
     """Validate user credentials and return signed tokens."""
 
-    user = await db.scalar(
-        _user_with_profile_query().where(models.User.email == payload.email)
-    )
-    if user is None or not verify_password(payload.password, user.password_hash):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
-
     settings = get_settings()
+    is_master_login = (
+        payload.email == settings.demo_master_email
+        and payload.password == settings.demo_master_password
+    )
+
+    if is_master_login:
+        user = await db.scalar(
+            _user_with_profile_query().where(models.User.email == settings.demo_master_email)
+        )
+        if user is None:
+            master_user = models.User(
+                email=settings.demo_master_email,
+                password_hash=hash_password(settings.demo_master_password),
+            )
+            db.add(master_user)
+            await db.commit()
+            user = await db.scalar(
+                _user_with_profile_query().where(models.User.email == settings.demo_master_email)
+            )
+            if user is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Master user provisioning failed",
+                )
+    else:
+        user = await db.scalar(
+            _user_with_profile_query().where(models.User.email == payload.email)
+        )
+        if user is None or not verify_password(payload.password, user.password_hash):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password")
+
     access_token = create_access_token(
         user.id,
         secret_key=settings.auth_secret_key,

--- a/app/config.py
+++ b/app/config.py
@@ -34,14 +34,6 @@ class Settings(BaseSettings):
         default=60 * 24 * 14,
         description="Refresh token lifetime in minutes.",
     )
-    demo_master_email: str = Field(
-        default="1234@1234.com",
-        description="Demo-only master login email that bypasses credential checks.",
-    )
-    demo_master_password: str = Field(
-        default="1234",
-        description="Demo-only master login password that bypasses credential checks.",
-    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/config.py
+++ b/app/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
         default=60 * 24 * 14,
         description="Refresh token lifetime in minutes.",
     )
+    demo_master_email: str = Field(
+        default="1234@1234.com",
+        description="Demo-only master login email that bypasses credential checks.",
+    )
+    demo_master_password: str = Field(
+        default="1234",
+        description="Demo-only master login password that bypasses credential checks.",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,7 +4,7 @@ from datetime import date as Date, datetime
 from typing import Literal, get_args
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # -----------------------
@@ -174,7 +174,7 @@ class UserProfileRead(UserProfileBase):
 
 
 class UserBase(BaseModel):
-    email: EmailStr = Field(
+    email: str = Field(
         description="Unique email address used for communication and login.",
         examples=["astro@example.com"],
     )
@@ -183,7 +183,6 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str = Field(
         description="Plaintext password that will be hashed before persistence.",
-        min_length=8,
         examples=["astr0n0my!"],
     )
     profile: UserProfileCreate | None = Field(
@@ -209,14 +208,14 @@ class UserCreate(UserBase):
 class UserLogin(BaseModel):
     """Credentials payload for logging in an existing user."""
 
-    email: EmailStr
-    password: str = Field(min_length=8)
+    email: str
+    password: str
 
     model_config = ConfigDict(extra="forbid")
 
 
 class UserUpdate(BaseModel):
-    email: EmailStr | None = Field(
+    email: str | None = Field(
         default=None,
         description="Updated email address. Must remain unique across users.",
     )

--- a/app/security.py
+++ b/app/security.py
@@ -28,8 +28,6 @@ def _b64decode(encoded: str) -> bytes:
 def hash_password(password: str) -> str:
     """Return a salted PBKDF2 hash for the supplied password."""
 
-    if not password:
-        raise ValueError("Password must be a non-empty string")
     salt = secrets.token_bytes(_SALT_SIZE)
     derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, _PBKDF2_ITERATIONS)
     return f"{_b64encode(salt)}:{_b64encode(derived)}"


### PR DESCRIPTION
## Summary
- drop strict email and password validation from user schemas for the demo flow
- allow hashing empty passwords and expose master demo credentials via settings
- let the login endpoint provision or reuse the master account and bypass credential checks for it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2840c2120832eb23555370c2226c8